### PR TITLE
Strip the release binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,8 @@ description = "An experimental ZK-rollup using ZoKrates circuits."
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[profile.release]
+strip = true
+
 [dependencies]
 clap = { version = "^4.3.12", features = ["derive"] }


### PR DESCRIPTION
Originally a part of #21.

The PR enables the [`strip` option](https://doc.rust-lang.org/cargo/reference/profiles.html#strip).

The release binaries that Rust creates by default still contain quite a lot of debug info. For example currently on #21 a release binary is 10.4 MB for an application that barely does anything. With stripping, it's 962 kB.

The main benefit of this extra info is that you can debug a release binary seeing function names, references to sources, etc. Also you get proper stack traces (see an example in [When to use symbol stripping in Rust release builds?](https://stackoverflow.com/questions/73628537/when-to-use-symbol-stripping-in-rust-release-builds)).

I'm a bit torn on this, but ballooning the size of the binary by 10x seems like a big price to pay. 10 MB is actually more than the whole Solidity compiler (not counting Z3). And with Solidity even this is a bit of a concern - we're paying a lot for bandwidth to serve older compiler versions. This is especially given that only a small fraction of people would even notice and those that would would also likely be capable of just rebuilding the binary. On the other hand, it's about 2 MB packed. so still not that unreasonable. But it will only grow.

All in all, I'd still rather have stripping enabled by default and have small binaries and only disable when it turns we actually do have a need for this.