### PR TITLE
Use thiserror crate to improve error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror",
 ]
 
 [[package]]
@@ -314,6 +315,26 @@ dependencies = [
  "redox_syscall",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,5 @@ strip = true
 clap = { version = "^4.3.12", features = ["derive"] }
 serde = { version = "^1", features = ["derive"] }
 serde_json = "^1"
+thiserror = "^1"
 tempfile = "^3"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use clap::Parser;
 use clap::Subcommand;
+use thiserror::Error;
 
 use crate::node::Node;
 use crate::node::NodeError;
@@ -11,9 +12,12 @@ use crate::transaction::Amount;
 use crate::wallet::Wallet;
 use crate::wallet::WalletError;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum CLIError {
+    #[error("Wallet error | {0}")]
     Wallet(WalletError),
+
+    #[error("Node error | {0}")]
     Node(NodeError),
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,6 @@ use crypt_roller::cli::run_cli;
 
 fn main() {
     if let Err(error) = run_cli() {
-        println!("ERROR: {:#?}", error);
+        println!("ERROR: {}", error);
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -4,6 +4,8 @@ pub mod state;
 
 use std::path::Path;
 
+use thiserror::Error;
+
 use crate::utils::storage::StorageError;
 
 use history::History;
@@ -11,9 +13,12 @@ use mempool::Mempool;
 use state::RollupState;
 use state::TransactionExecutionError;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum NodeError {
+    #[error("Error while executing transaction | {0}")]
     Transaction(TransactionExecutionError),
+
+    #[error("Storage error | {0}")]
     Storage(StorageError),
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -16,10 +16,10 @@ use state::TransactionExecutionError;
 #[derive(Error, Debug)]
 pub enum NodeError {
     #[error("Error while executing transaction | {0}")]
-    Transaction(TransactionExecutionError),
+    Transaction(#[from] TransactionExecutionError),
 
     #[error("Storage error | {0}")]
-    Storage(StorageError),
+    Storage(#[from] StorageError),
 }
 
 #[derive(Debug)]
@@ -40,10 +40,8 @@ impl Node {
 
     pub fn start(storage_dir: &Path) -> Result<Self, NodeError> {
         let mut node = Self {
-            mempool: Mempool::load(&storage_dir.join("mempool.json"))
-                .map_err(NodeError::Storage)?,
-            history: History::load(&storage_dir.join("history.json"))
-                .map_err(NodeError::Storage)?,
+            mempool: Mempool::load(&storage_dir.join("mempool.json"))?,
+            history: History::load(&storage_dir.join("history.json"))?,
             state: RollupState::new(),
         };
 
@@ -52,12 +50,8 @@ impl Node {
     }
 
     pub fn update_storage(&self, storage_dir: &Path) -> Result<(), NodeError> {
-        self.history
-            .save(&storage_dir.join("history.json"))
-            .map_err(NodeError::Storage)?;
-        self.mempool
-            .save(&storage_dir.join("mempool.json"))
-            .map_err(NodeError::Storage)?;
+        self.history.save(&storage_dir.join("history.json"))?;
+        self.mempool.save(&storage_dir.join("mempool.json"))?;
         Ok(())
     }
 
@@ -76,9 +70,7 @@ impl Node {
         );
         for batch in self.history.batches()[*self.state.batch_count()..self.history.len()].iter() {
             println!("    -> Applying {} transactions.", batch.len());
-            self.state
-                .apply_batch(batch.transactions())
-                .map_err(NodeError::Transaction)?;
+            self.state.apply_batch(batch.transactions())?;
             for transaction in batch.transactions().iter() {
                 self.mempool.drop_transaction(transaction);
             }

--- a/src/node/state.rs
+++ b/src/node/state.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use thiserror::Error;
+
 use crate::transaction::Address;
 use crate::transaction::Amount;
 use crate::transaction::Enter;
@@ -7,26 +9,41 @@ use crate::transaction::Nonce;
 use crate::transaction::Transaction;
 use crate::transaction::Transfer;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum TransactionExecutionError {
-    SourceAccountMissing {
-        transfer: Transfer,
-    },
-    TargetAccountMissing {
-        transfer: Transfer,
-    },
+    #[error("Source account {} does not exist.", .transfer.from)]
+    SourceAccountMissing { transfer: Transfer },
+
+    #[error("Target account {} does not exist.", .transfer.from)]
+    TargetAccountMissing { transfer: Transfer },
+
+    #[error("Wrong nonce. Expected {}, got {}.", .account.next_nonce, .transfer.nonce)]
     WrongNonce {
         transfer: Transfer,
         account: AccountState,
     },
+
+    #[error(
+        "Insufficient balance. Attempted to transfer {} out of an account with balance {}.",
+        .amount,
+        .account.balance,
+    )]
     InsufficientBalance {
         account: AccountState,
         amount: Amount,
     },
+
+    #[error("Balance overflow. Transferring {} to an account with balance {} would bring it over the maximum of {}.",
+        .amount,
+        .account.balance,
+        Amount::MAX,
+    )]
     BalanceOverflow {
         account: AccountState,
         amount: Amount,
     },
+
+    #[error("Nonce overflow.")]
     NonceOverflow,
 }
 

--- a/src/utils/storage.rs
+++ b/src/utils/storage.rs
@@ -5,21 +5,23 @@ use std::path::PathBuf;
 
 use serde::Deserialize;
 use serde::Serialize;
+use thiserror::Error;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum StorageError {
-    FileReadError {
-        error: io::Error,
-        file: PathBuf,
-    },
-    FileWriteError {
-        error: io::Error,
-        file: PathBuf,
-    },
+    #[error("File read error for '{file}' | {error}")]
+    FileReadError { error: io::Error, file: PathBuf },
+
+    #[error("File write error for '{file}' | {error}")]
+    FileWriteError { error: io::Error, file: PathBuf },
+
+    #[error("Error while decoding '{file}' as JSON | {error}")]
     JSONDecodingError {
         error: serde_json::Error,
         file: PathBuf,
     },
+
+    #[error("Error while encoding JSON into '{file}' | {error}")]
     JSONEncodingError {
         error: serde_json::Error,
         file: PathBuf,

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 mod tests;
 
+use thiserror::Error;
+
 use crate::node::Node;
 use crate::transaction::Address;
 use crate::transaction::Amount;
@@ -8,9 +10,12 @@ use crate::transaction::Enter;
 use crate::transaction::Transaction;
 use crate::transaction::Transfer;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum WalletError {
+    #[error("Insufficient balance.")]
     InsufficientBalance,
+
+    #[error("Invalid address.")]
     InvalidAddress,
 }
 


### PR DESCRIPTION
Depends on #21.

The current error handling code is IMO a lot more cumbersome than it should be:
- I'm forced to use `.map_err()` constantly to map one error type to another. I could get automatic conversion, but this requires implementing the [`From` trait](https://doc.rust-lang.org/std/convert/trait.From.html), which adds some boilerplate.
- There are no proper error messages. The error enum is just debug printed to the output.

I decided to use the popular [thiserror crate](https://docs.rs/thiserror/), which solves both problems.